### PR TITLE
Use CMAKE_INSTALL_PREFIX

### DIFF
--- a/install/CMakeLists.txt
+++ b/install/CMakeLists.txt
@@ -6,7 +6,7 @@ install(
     DIRECTORY
     "../include/"
     DESTINATION
-    "/usr/include"
+    include
     FILES_MATCHING
     PATTERN
     "*.hpp"


### PR DESCRIPTION
Hey, thanks for this library! This PR allows users to use `CMAKE_INSTALL_PREFIX` to set the install path.

```sh
cd install
mkdir build
cd build
cmake .. -DCMAKE_INSTALL_PREFIX=/tmp
make install
```