### PR TITLE
fixed missing namespace

### DIFF
--- a/include/NumCpp/Core/Internal/StaticAsserts.hpp
+++ b/include/NumCpp/Core/Internal/StaticAsserts.hpp
@@ -35,18 +35,18 @@
     static_assert(nc::is_valid_dtype_v<dtype>, "Template type is not a valid dtype for NdArray")
 
 #define STATIC_ASSERT_ARITHMETIC(dtype) \
-    static_assert(is_arithmetic_v<dtype>, "Can only be used with arithmetic types")
+    static_assert(nc::is_arithmetic_v<dtype>, "Can only be used with arithmetic types")
 
 #define STATIC_ASSERT_INTEGER(dtype) \
-    static_assert(is_integral_v<dtype>, "Can only be used with integer types")
+    static_assert(nc::is_integral_v<dtype>, "Can only be used with integer types")
 
 #define STATIC_ASSERT_FLOAT(dtype) \
-    static_assert(is_floating_point_v<dtype>, "Can only be used with float types")
+    static_assert(nc::is_floating_point_v<dtype>, "Can only be used with float types")
 
 #define STATIC_ASSERT_COMPLEX(dtype) \
-    static_assert(is_complex_v<dtype>, \
+    static_assert(nc::is_complex_v<dtype>, \
     "Can only be used with std::complex types")
 
 #define STATIC_ASSERT_ARITHMETIC_OR_COMPLEX(dtype) \
-    static_assert(std::is_arithmetic<dtype>::value || is_complex_v<dtype>, \
+    static_assert(std::is_arithmetic<dtype>::value || nc::is_complex_v<dtype>, \
     "Can only be used with arithmetic types or std::complex types")


### PR DESCRIPTION
Hello!

Some functions are missing namespace 'nc'.