### PR TITLE
Install CMake config files into architecture-dependent location

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -181,21 +181,19 @@ write_basic_package_version_file("${PROJECT_NAME}ConfigVersion.cmake"
 configure_package_config_file(
     "${PROJECT_SOURCE_DIR}/cmake/${PROJECT_NAME}Config.cmake.in"
     "${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
-    INSTALL_DESTINATION
-    ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}/cmake
+    INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
 )
 
 install(EXPORT ${PROJECT_NAME}_Targets
     FILE ${PROJECT_NAME}Targets.cmake
     NAMESPACE ${PROJECT_NAME}::
-    DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}/cmake
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
 )
 
 install(FILES 
     "${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"   
     "${PROJECT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
-    DESTINATION 
-    ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}/cmake
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
 )
 
 install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/ DESTINATION include)


### PR DESCRIPTION
The CMake files may be more apprpriate to be installed into arch-dependent location, which normally is `"${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"` and the location is adopted by many C++ libraries.

Ref: https://gitlab.kitware.com/cmake/cmake/-/issues/18453
https://github.com/jbeder/yaml-cpp/pull/1055
https://github.com/google/googletest/blob/main/googletest/CMakeLists.txt#L99-L109