### PR TITLE
test: Add cppcheck and multiple tests to ctest.

### DIFF
--- a/test/cppcheck/CMakeLists.txt
+++ b/test/cppcheck/CMakeLists.txt
@@ -11,3 +11,6 @@ target_include_directories(${TARGET_NAME} PRIVATE
 target_link_libraries(${TARGET_NAME} PRIVATE 
     ${ALL_INTERFACE_TARGET}
 )
+
+add_test(NAME ${TARGET_NAME}
+    COMMAND ${TARGET_NAME})

--- a/test/multiple/CMakeLists.txt
+++ b/test/multiple/CMakeLists.txt
@@ -18,3 +18,6 @@ target_include_directories(${TARGET_NAME} PRIVATE
 target_link_libraries(${TARGET_NAME} PRIVATE 
     ${ALL_INTERFACE_TARGET}
 )
+
+add_test(NAME ${TARGET_NAME}
+    COMMAND ${TARGET_NAME})


### PR DESCRIPTION
Make `cppcheck` and `multiple` tests easier to run by adding them to ctest.